### PR TITLE
Implement LruCache by Factory class

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,17 @@ dependencies {
 
 Creating a Bitmap from the `StopBadgeFactory` class
 ```
-Bitmap myBitmap = StopBadgeFactory.worker().fromArrowUp().setShadowColor(Color.RED).create()
+//Initialize a StopBadge class, set any attributes you need.
+StopBadge stopBadge = new StopBadge();
+stopBadge.setShape(anyShape);
+...
+ 
+/*
+ * Retrieve the Bitmap from cache if it exists, else create it and save it to cache.
+ * Different Sizes of the same StopBadge are cached independently.
+ */
+
+Bitmap myBitmap = StopBadgeFactory.getBitmap(stopBadge, size);
 ```
 
 Using the custom layout in XML:

--- a/README.md
+++ b/README.md
@@ -33,6 +33,12 @@ dependencies {
 
 ## Usage
 
+Creating a Bitmap from the `StopBadgeFactory` class
+```
+Bitmap myBitmap = StopBadgeFactory.worker().fromArrowUp().setShadowColor(Color.RED).create()
+```
+
+Using the custom layout in XML:
 ```xml
 <com.liefery.android.stop_badge.StopBadgeView
     android:layout_width="50dp"

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -9,7 +9,7 @@ object Settings {
             "-source" :: "1.7" ::
             "-target" :: "1.7" ::
             Nil,
-        minSdkVersion := "11",
+        minSdkVersion := "12",
         organization := "com.liefery.android",
         platformTarget := "android-26",
         resolvers += "jitpack" at "https://jitpack.io",

--- a/sample/src/main/res/layout/main.xml
+++ b/sample/src/main/res/layout/main.xml
@@ -252,8 +252,8 @@
                 android:layout_width="50dp"
                 android:layout_height="50dp"
                 app:stopBadge_circleColor="#428e92"
-                app:stopBadge_shadowDx="-20dp"
-                app:stopBadge_shadowDy="30dp"
+                app:stopBadge_shadowDx="-1dp"
+                app:stopBadge_shadowDy="1dp"
                 app:stopBadge_shadowRadius="3dp"
                 app:stopBadge_stopNumber="6" />
 

--- a/sample/src/main/res/layout/main.xml
+++ b/sample/src/main/res/layout/main.xml
@@ -225,8 +225,8 @@
                 android:layout_width="50dp"
                 android:layout_height="50dp"
                 app:stopBadge_circleColor="#428e92"
-                app:stopBadge_shadowDx="-1dp"
-                app:stopBadge_shadowDy="1dp"
+                app:stopBadge_shadowDx="-20dp"
+                app:stopBadge_shadowDy="30dp"
                 app:stopBadge_shadowRadius="3dp"
                 app:stopBadge_stopNumber="6" />
 

--- a/sample/src/main/res/layout/main.xml
+++ b/sample/src/main/res/layout/main.xml
@@ -213,6 +213,33 @@
         </LinearLayout>
 
         <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="8dp"
+                android:clipChildren="false"
+                android:gravity="center_vertical"
+                android:orientation="horizontal"
+                android:weightSum="1">
+
+            <com.liefery.android.stop_badge.StopBadgeView
+                    android:layout_width="50dp"
+                    android:layout_height="50dp"
+                    app:stopBadge_circleColor="#4f83cc"
+                    app:stopBadge_shape="arrowDown" />
+
+            <TextView
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_weight="1"
+                    android:layout_marginLeft="16dp"
+                    android:text="Identical badges are loaded from cache instead of recreating them."
+                    android:textColor="#262626"
+                    android:textSize="16sp"
+                    android:textStyle="bold" />
+
+        </LinearLayout>
+
+        <LinearLayout
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:layout_marginTop="8dp"

--- a/src/main/java/com/liefery/android/stop_badge/StopBadge.java
+++ b/src/main/java/com/liefery/android/stop_badge/StopBadge.java
@@ -4,8 +4,6 @@ import android.graphics.*;
 import android.support.annotation.ColorInt;
 import android.support.annotation.FloatRange;
 
-import java.security.MessageDigest;
-
 import static android.graphics.Paint.ANTI_ALIAS_FLAG;
 
 public class StopBadge {
@@ -59,8 +57,6 @@ public class StopBadge {
 
     private int shadowColor = Color.argb( 125, 0, 0, 0 );
 
-    private int circleColor = Color.TRANSPARENT;
-
     private float shadowDx = 0;
 
     private float shadowDy = 0;
@@ -86,6 +82,7 @@ public class StopBadge {
     public StopBadge() {
         textPaint.setTypeface( Typeface
                         .create( Typeface.DEFAULT, Typeface.BOLD ) );
+        setShapeColor( Color.TRANSPARENT );
     }
 
     public Path getShape() {
@@ -142,7 +139,6 @@ public class StopBadge {
     }
 
     public void setShapeColor( @ColorInt int color ) {
-        circleColor = color;
         shapePaint.setColor( color );
     }
 
@@ -254,7 +250,8 @@ public class StopBadge {
         builder.append( shadowDx );
         builder.append( shadowDy );
         builder.append( circlePaint.getAlpha() );
-        builder.append( circleColor );
+        builder.append( circlePaint.getColor() );
+        builder.append( shapePaint.getColor() );
         return Integer.toString( builder.toString().hashCode() ) + "_" + size;
     }
 

--- a/src/main/java/com/liefery/android/stop_badge/StopBadge.java
+++ b/src/main/java/com/liefery/android/stop_badge/StopBadge.java
@@ -4,6 +4,8 @@ import android.graphics.*;
 import android.support.annotation.ColorInt;
 import android.support.annotation.FloatRange;
 
+import java.security.MessageDigest;
+
 import static android.graphics.Paint.ANTI_ALIAS_FLAG;
 
 public class StopBadge {
@@ -41,6 +43,8 @@ public class StopBadge {
         SHAPE_ARROW_DOWN = arrowDown;
     }
 
+    private String pathContents = "empty";
+
     private float alpha = 1;
 
     private final Path circlePath = new Path();
@@ -54,6 +58,8 @@ public class StopBadge {
     private final Path adjustedShape = new Path();
 
     private int shadowColor = Color.argb( 125, 0, 0, 0 );
+
+    private int circleColor = Color.TRANSPARENT;
 
     private float shadowDx = 0;
 
@@ -80,7 +86,6 @@ public class StopBadge {
     public StopBadge() {
         textPaint.setTypeface( Typeface
                         .create( Typeface.DEFAULT, Typeface.BOLD ) );
-        setShapeColor( Color.TRANSPARENT );
     }
 
     public Path getShape() {
@@ -93,10 +98,12 @@ public class StopBadge {
     }
 
     public void setShapeArrowUp() {
+        this.pathContents = "arrow_up";
         setShape( SHAPE_ARROW_UP );
     }
 
     public void setShapeArrowDown() {
+        this.pathContents = "arrow_down";
         setShape( SHAPE_ARROW_DOWN );
     }
 
@@ -104,6 +111,8 @@ public class StopBadge {
      * Converts the number's text-representation to an unadjusted Path
      */
     public void setStopNumber( int stopNumber ) {
+        this.pathContents = "num(" + stopNumber + ")";
+
         if ( stopNumber < 0 ) {
             throw new IllegalArgumentException( "stopNumber must be >= 0" );
         }
@@ -133,6 +142,7 @@ public class StopBadge {
     }
 
     public void setShapeColor( @ColorInt int color ) {
+        circleColor = color;
         shapePaint.setColor( color );
     }
 
@@ -236,7 +246,19 @@ public class StopBadge {
         return (int) ( shadowRadius + Math.abs( shadowDx ) );
     }
 
-    public Bitmap export( int size ) {
+    public String toKey( int size ) {
+        StringBuilder builder = new StringBuilder();
+        builder.append( pathContents );
+        builder.append( shadowRadius );
+        builder.append( shadowColor );
+        builder.append( shadowDx );
+        builder.append( shadowDy );
+        builder.append( circlePaint.getAlpha() );
+        builder.append( circleColor );
+        return Integer.toString( builder.toString().hashCode() ) + "_" + size;
+    }
+
+    protected Bitmap export( int size ) {
         Bitmap bitmap = Bitmap.createBitmap( size + shadowSizeX() * 2, size
             + shadowSizeY() * 2, Bitmap.Config.ARGB_8888 );
         int width = bitmap.getWidth();

--- a/src/main/java/com/liefery/android/stop_badge/StopBadgeFactory.java
+++ b/src/main/java/com/liefery/android/stop_badge/StopBadgeFactory.java
@@ -2,301 +2,34 @@ package com.liefery.android.stop_badge;
 
 import android.annotation.SuppressLint;
 import android.graphics.*;
-import android.support.annotation.ColorInt;
-import android.support.annotation.FloatRange;
+import android.util.Log;
 import android.util.LruCache;
 
-import static android.graphics.Paint.ANTI_ALIAS_FLAG;
-
+@SuppressLint( "NewApi" )
 public class StopBadgeFactory {
 
     private static StopBadgeFactory instance = null;
+
     private BadgeCache cache = new BadgeCache();
 
     protected StopBadgeFactory() {
         // Exists only to defeat instantiation.
     }
 
-    public static StopBadgeFactory worker() {
+    public static Bitmap getBitmap( StopBadge badge, int size ) {
         if ( instance == null ) {
             instance = new StopBadgeFactory();
         }
-        return instance;
-    }
 
-    public static StopBadgeCommonAttributesEditor fromArrowUp() {
-        return new StopBadgeCommonAttributesEditor(
-            StopBadgeCommonAttributesEditor.ArrowDirection.UP );
-    }
-
-    public static StopBadgeCommonAttributesEditor fromArrowDown() {
-        return new StopBadgeCommonAttributesEditor(
-            StopBadgeCommonAttributesEditor.ArrowDirection.DOWN );
-    }
-
-    public static StopBadgeCommonAttributesEditor fromNumber( int number ) {
-        return new StopBadgeCommonAttributesEditor( number );
-    }
-
-    public static StopBadgeCommonAttributesEditor fromPath( Path path ) {
-        return new StopBadgeCommonAttributesEditor( path );
-    }
-
-    public static StopBadgeCommonAttributesEditor fromNothing() {
-        return new StopBadgeCommonAttributesEditor();
-    }
-
-    public static class StopBadgeCommonAttributesEditor {
-
-        static final Path SHAPE_ARROW_UP;
-
-        static final Path SHAPE_ARROW_DOWN;
-
-        static {
-            Path arrowUp = new Path();
-            arrowUp.moveTo( .5f, 0 );
-            arrowUp.lineTo( .1f, .4f );
-            arrowUp.lineTo( .1f, .65f );
-            arrowUp.lineTo( .4f, .35f );
-            arrowUp.lineTo( .4f, 1f );
-            arrowUp.lineTo( .6f, 1f );
-            arrowUp.lineTo( .6f, .35f );
-            arrowUp.lineTo( .9f, .65f );
-            arrowUp.lineTo( .9f, .4f );
-            arrowUp.lineTo( .5f, 0 );
-            arrowUp.close();
-            SHAPE_ARROW_UP = arrowUp;
-
-            Path arrowDown = new Path();
-            arrowDown.moveTo( .4f, 0 );
-            arrowDown.lineTo( .4f, .65f );
-            arrowDown.lineTo( .1f, .35f );
-            arrowDown.lineTo( .1f, .6f );
-            arrowDown.lineTo( .5f, 1 );
-            arrowDown.lineTo( .9f, .6f );
-            arrowDown.lineTo( .9f, .35f );
-            arrowDown.lineTo( .6f, .65f );
-            arrowDown.lineTo( .6f, 0 );
-            arrowDown.lineTo( .4f, 0 );
-            arrowDown.close();
-            SHAPE_ARROW_DOWN = arrowDown;
-        }
-
-        private float alpha = 1;
-
-        private final Path circlePath = new Path();
-
-        private final Paint circlePaint = new Paint( ANTI_ALIAS_FLAG );
-
-        private Path shapePath = new Path();
-
-        private Paint shapePaint = new Paint( ANTI_ALIAS_FLAG );
-
-        private final Path adjustedShape = new Path();
-
-        private int shadowColor = Color.argb( 125, 0, 0, 0 );
-
-        private float shadowDx = 0;
-
-        private float shadowDy = 0;
-
-        private float shadowRadius = 0;
-
-        private final Paint shadowPaint = new Paint( ANTI_ALIAS_FLAG );
-
-        private final Paint textPaint = new Paint();
-
-        private float scale = 1;
-
-        /**
-         * Cache object to be reused
-         */
-        private RectF bounds = new RectF();
-
-        /**
-         * Cache object to be reused
-         */
-        private Matrix matrix = new Matrix();
-
-        enum ArrowDirection {
-            UP, DOWN
-        }
-
-        StopBadgeCommonAttributesEditor() {
-            setShapeColor( Color.TRANSPARENT );
-        }
-
-        StopBadgeCommonAttributesEditor( ArrowDirection arrowDirection ) {
-            this.scale = .55f;
-            switch ( arrowDirection ) {
-                case UP:
-                    this.shapePath = SHAPE_ARROW_DOWN;
-                case DOWN:
-                    this.shapePath = SHAPE_ARROW_DOWN;
-            }
-
-            setShapeColor( Color.TRANSPARENT );
-        }
-
-        StopBadgeCommonAttributesEditor( int stopNumber ) {
-            if ( stopNumber < 0 ) {
-                throw new IllegalArgumentException( "stopNumber must be >= 0" );
-            }
-
-            if ( stopNumber < 10 )
-                this.scale = .5f;
-            else if ( stopNumber < 100 )
-                this.scale = .6f;
-            else
-                this.scale = .7f;
-
-            Path path = new Path();
-            numberToPath( stopNumber, path );
-            this.shapePath = path;
-
-            setShapeColor( Color.TRANSPARENT );
-        }
-
-        StopBadgeCommonAttributesEditor( Path path ) {
-            this.scale = .55f;
-            this.shapePath = path;
-
-            setShapeColor( Color.TRANSPARENT );
-        }
-
-        public StopBadgeCommonAttributesEditor setCircleColor(
-            @ColorInt int color ) {
-            circlePaint.setColor( color );
-            return this;
-        }
-
-        public StopBadgeCommonAttributesEditor setShapeColor(
-            @ColorInt int color ) {
-            shapePaint.setColor( color );
-            return this;
-        }
-
-        public StopBadgeCommonAttributesEditor setShadowColor( int color ) {
-            this.shadowColor = color;
-            return this;
-        }
-
-        public StopBadgeCommonAttributesEditor setShadowDx( float dx ) {
-            this.shadowDx = dx;
-            return this;
-        }
-
-        public StopBadgeCommonAttributesEditor setShadowDy( float dy ) {
-            this.shadowDy = dy;
-            return this;
-        }
-
-        public StopBadgeCommonAttributesEditor setShadowRadius( float radius ) {
-            this.shadowRadius = radius;
-            return this;
-        }
-
-        public StopBadgeCommonAttributesEditor setAlpha(
-            @FloatRange( from = 0.0, to = 1.0 ) float alpha ) {
-            float circleAlpha = circlePaint.getAlpha() / 255f;
-            circlePaint.setAlpha( (int) ( 255 * alpha * circleAlpha ) );
-            float shapeAlpha = shapePaint.getAlpha() / 255f;
-            shapePaint.setAlpha( (int) ( 255 * alpha * shapeAlpha ) );
-            return this;
-        }
-
-        public Bitmap create( int size ) {
-            Bitmap bitmap = Bitmap.createBitmap( size + shadowSizeX() * 2, size
-                + shadowSizeY() * 2, Bitmap.Config.ARGB_8888 );
-            int width = bitmap.getWidth();
-            int height = bitmap.getHeight();
-            Canvas canvas = new Canvas( bitmap );
-
-            circlePath.reset();
-            circlePath.addCircle(
-                width / 2f,
-                height / 2f,
-                size / 2f,
-                Path.Direction.CW );
-
-            adjustPath( shapePath, width, height, size );
-
-            circlePath.setFillType( Path.FillType.EVEN_ODD );
-            circlePath.addPath( adjustedShape );
-            drawShadow( canvas, circlePath );
-            canvas.drawPath( circlePath, circlePaint );
-
-            if ( !isShapeTransparent() ) {
-                canvas.drawPath( adjustedShape, shapePaint );
-            }
-
-            return bitmap;
-        }
-
-        private int shadowSizeX() {
-            return (int) ( shadowRadius + Math.abs( shadowDx ) );
-        }
-
-        private int shadowSizeY() {
-            return (int) ( shadowRadius + Math.abs( shadowDy ) );
-        }
-
-        private boolean isShapeTransparent() {
-            return shapePaint.getAlpha() == 0;
-        }
-
-        private void drawShadow( Canvas canvas, Path shape ) {
-            if ( shadowRadius > 0 ) {
-                shadowPaint.setShadowLayer(
-                    shadowRadius,
-                    shadowDx,
-                    shadowDy,
-                    shadowColor );
-                canvas.drawPath( shape, shadowPaint );
-                circlePaint.setXfermode( new PorterDuffXfermode(
-                    PorterDuff.Mode.SRC_IN ) );
-            } else
-                circlePaint.setXfermode( null );
-        }
-
-        private void numberToPath( int stopNumber, Path path ) {
-            Paint textPaint = new Paint();
-            textPaint.setTypeface( Typeface.create(
-                Typeface.DEFAULT,
-                Typeface.BOLD ) );
-
-            String value = String.valueOf( stopNumber );
-            textPaint.setTextSize( 10 );
-            textPaint.getTextPath( value, 0, value.length(), 0, 0, path );
-        }
-
-        private void adjustPath(
-            Path shape,
-            float outerWidth,
-            float outerHeight,
-            float circleSize ) {
-            adjustedShape.reset();
-            adjustedShape.addPath( shape );
-
-            adjustedShape.computeBounds( bounds, true );
-            float currentSize = Math.max( bounds.width(), bounds.height() );
-            float scale = circleSize / currentSize * this.scale;
-            matrix.reset();
-            matrix.setScale( scale, scale );
-            adjustedShape.transform( matrix );
-
-            adjustedShape.computeBounds( bounds, true );
-            float centerX = outerWidth / 2;
-            float centerY = outerHeight / 2;
-            matrix.reset();
-            matrix.setTranslate(
-                centerX - ( bounds.right + bounds.left ) / 2,
-                centerY - ( bounds.bottom + bounds.top ) / 2 );
-            adjustedShape.transform( matrix );
+        if ( instance.cache.get( badge.toKey( size ) ) == null ) {
+            Bitmap newBadge = badge.export( size );
+            instance.cache.put( badge.toKey( size ), newBadge );
+            return newBadge;
+        } else {
+            return instance.cache.get( badge.toKey( size ) );
         }
     }
 
-    @SuppressLint("NewApi")
     public class BadgeCache extends LruCache<String, Bitmap> {
         BadgeCache() {
             super( 2 * 1024 * 1024 ); // 2MiB

--- a/src/main/java/com/liefery/android/stop_badge/StopBadgeFactory.java
+++ b/src/main/java/com/liefery/android/stop_badge/StopBadgeFactory.java
@@ -1,23 +1,29 @@
 package com.liefery.android.stop_badge;
 
-import android.annotation.SuppressLint;
+import android.app.ActivityManager;
+import android.content.Context;
 import android.graphics.*;
 import android.util.LruCache;
 
-@SuppressLint( "NewApi" )
 public class StopBadgeFactory {
 
     private static StopBadgeFactory instance = null;
 
-    private BadgeCache cache = new BadgeCache();
+    private LruCache<String, Bitmap> cache;
 
     protected StopBadgeFactory() {
         // Exists only to defeat instantiation.
     }
 
-    public static Bitmap getBitmap( StopBadge badge, int size ) {
+    public static Bitmap getBitmap( Context context, StopBadge badge, int size ) {
         if ( instance == null ) {
             instance = new StopBadgeFactory();
+
+            int memClass = ( (ActivityManager) context
+                            .getSystemService( Context.ACTIVITY_SERVICE ) )
+                            .getMemoryClass();
+            int cacheSize = 1024 * 1024 * memClass / 8;
+            instance.cache = new LruCache<String, Bitmap>( cacheSize );
         }
 
         if ( instance.cache.get( badge.toKey( size ) ) == null ) {
@@ -26,12 +32,6 @@ public class StopBadgeFactory {
             return newBadge;
         } else {
             return instance.cache.get( badge.toKey( size ) );
-        }
-    }
-
-    public class BadgeCache extends LruCache<String, Bitmap> {
-        BadgeCache() {
-            super( 2 * 1024 * 1024 ); // 2MiB
         }
     }
 }

--- a/src/main/java/com/liefery/android/stop_badge/StopBadgeFactory.java
+++ b/src/main/java/com/liefery/android/stop_badge/StopBadgeFactory.java
@@ -1,0 +1,305 @@
+package com.liefery.android.stop_badge;
+
+import android.annotation.SuppressLint;
+import android.graphics.*;
+import android.support.annotation.ColorInt;
+import android.support.annotation.FloatRange;
+import android.util.LruCache;
+
+import static android.graphics.Paint.ANTI_ALIAS_FLAG;
+
+public class StopBadgeFactory {
+
+    private static StopBadgeFactory instance = null;
+    private BadgeCache cache = new BadgeCache();
+
+    protected StopBadgeFactory() {
+        // Exists only to defeat instantiation.
+    }
+
+    public static StopBadgeFactory worker() {
+        if ( instance == null ) {
+            instance = new StopBadgeFactory();
+        }
+        return instance;
+    }
+
+    public static StopBadgeCommonAttributesEditor fromArrowUp() {
+        return new StopBadgeCommonAttributesEditor(
+            StopBadgeCommonAttributesEditor.ArrowDirection.UP );
+    }
+
+    public static StopBadgeCommonAttributesEditor fromArrowDown() {
+        return new StopBadgeCommonAttributesEditor(
+            StopBadgeCommonAttributesEditor.ArrowDirection.DOWN );
+    }
+
+    public static StopBadgeCommonAttributesEditor fromNumber( int number ) {
+        return new StopBadgeCommonAttributesEditor( number );
+    }
+
+    public static StopBadgeCommonAttributesEditor fromPath( Path path ) {
+        return new StopBadgeCommonAttributesEditor( path );
+    }
+
+    public static StopBadgeCommonAttributesEditor fromNothing() {
+        return new StopBadgeCommonAttributesEditor();
+    }
+
+    public static class StopBadgeCommonAttributesEditor {
+
+        static final Path SHAPE_ARROW_UP;
+
+        static final Path SHAPE_ARROW_DOWN;
+
+        static {
+            Path arrowUp = new Path();
+            arrowUp.moveTo( .5f, 0 );
+            arrowUp.lineTo( .1f, .4f );
+            arrowUp.lineTo( .1f, .65f );
+            arrowUp.lineTo( .4f, .35f );
+            arrowUp.lineTo( .4f, 1f );
+            arrowUp.lineTo( .6f, 1f );
+            arrowUp.lineTo( .6f, .35f );
+            arrowUp.lineTo( .9f, .65f );
+            arrowUp.lineTo( .9f, .4f );
+            arrowUp.lineTo( .5f, 0 );
+            arrowUp.close();
+            SHAPE_ARROW_UP = arrowUp;
+
+            Path arrowDown = new Path();
+            arrowDown.moveTo( .4f, 0 );
+            arrowDown.lineTo( .4f, .65f );
+            arrowDown.lineTo( .1f, .35f );
+            arrowDown.lineTo( .1f, .6f );
+            arrowDown.lineTo( .5f, 1 );
+            arrowDown.lineTo( .9f, .6f );
+            arrowDown.lineTo( .9f, .35f );
+            arrowDown.lineTo( .6f, .65f );
+            arrowDown.lineTo( .6f, 0 );
+            arrowDown.lineTo( .4f, 0 );
+            arrowDown.close();
+            SHAPE_ARROW_DOWN = arrowDown;
+        }
+
+        private float alpha = 1;
+
+        private final Path circlePath = new Path();
+
+        private final Paint circlePaint = new Paint( ANTI_ALIAS_FLAG );
+
+        private Path shapePath = new Path();
+
+        private Paint shapePaint = new Paint( ANTI_ALIAS_FLAG );
+
+        private final Path adjustedShape = new Path();
+
+        private int shadowColor = Color.argb( 125, 0, 0, 0 );
+
+        private float shadowDx = 0;
+
+        private float shadowDy = 0;
+
+        private float shadowRadius = 0;
+
+        private final Paint shadowPaint = new Paint( ANTI_ALIAS_FLAG );
+
+        private final Paint textPaint = new Paint();
+
+        private float scale = 1;
+
+        /**
+         * Cache object to be reused
+         */
+        private RectF bounds = new RectF();
+
+        /**
+         * Cache object to be reused
+         */
+        private Matrix matrix = new Matrix();
+
+        enum ArrowDirection {
+            UP, DOWN
+        }
+
+        StopBadgeCommonAttributesEditor() {
+            setShapeColor( Color.TRANSPARENT );
+        }
+
+        StopBadgeCommonAttributesEditor( ArrowDirection arrowDirection ) {
+            this.scale = .55f;
+            switch ( arrowDirection ) {
+                case UP:
+                    this.shapePath = SHAPE_ARROW_DOWN;
+                case DOWN:
+                    this.shapePath = SHAPE_ARROW_DOWN;
+            }
+
+            setShapeColor( Color.TRANSPARENT );
+        }
+
+        StopBadgeCommonAttributesEditor( int stopNumber ) {
+            if ( stopNumber < 0 ) {
+                throw new IllegalArgumentException( "stopNumber must be >= 0" );
+            }
+
+            if ( stopNumber < 10 )
+                this.scale = .5f;
+            else if ( stopNumber < 100 )
+                this.scale = .6f;
+            else
+                this.scale = .7f;
+
+            Path path = new Path();
+            numberToPath( stopNumber, path );
+            this.shapePath = path;
+
+            setShapeColor( Color.TRANSPARENT );
+        }
+
+        StopBadgeCommonAttributesEditor( Path path ) {
+            this.scale = .55f;
+            this.shapePath = path;
+
+            setShapeColor( Color.TRANSPARENT );
+        }
+
+        public StopBadgeCommonAttributesEditor setCircleColor(
+            @ColorInt int color ) {
+            circlePaint.setColor( color );
+            return this;
+        }
+
+        public StopBadgeCommonAttributesEditor setShapeColor(
+            @ColorInt int color ) {
+            shapePaint.setColor( color );
+            return this;
+        }
+
+        public StopBadgeCommonAttributesEditor setShadowColor( int color ) {
+            this.shadowColor = color;
+            return this;
+        }
+
+        public StopBadgeCommonAttributesEditor setShadowDx( float dx ) {
+            this.shadowDx = dx;
+            return this;
+        }
+
+        public StopBadgeCommonAttributesEditor setShadowDy( float dy ) {
+            this.shadowDy = dy;
+            return this;
+        }
+
+        public StopBadgeCommonAttributesEditor setShadowRadius( float radius ) {
+            this.shadowRadius = radius;
+            return this;
+        }
+
+        public StopBadgeCommonAttributesEditor setAlpha(
+            @FloatRange( from = 0.0, to = 1.0 ) float alpha ) {
+            float circleAlpha = circlePaint.getAlpha() / 255f;
+            circlePaint.setAlpha( (int) ( 255 * alpha * circleAlpha ) );
+            float shapeAlpha = shapePaint.getAlpha() / 255f;
+            shapePaint.setAlpha( (int) ( 255 * alpha * shapeAlpha ) );
+            return this;
+        }
+
+        public Bitmap create( int size ) {
+            Bitmap bitmap = Bitmap.createBitmap( size + shadowSizeX() * 2, size
+                + shadowSizeY() * 2, Bitmap.Config.ARGB_8888 );
+            int width = bitmap.getWidth();
+            int height = bitmap.getHeight();
+            Canvas canvas = new Canvas( bitmap );
+
+            circlePath.reset();
+            circlePath.addCircle(
+                width / 2f,
+                height / 2f,
+                size / 2f,
+                Path.Direction.CW );
+
+            adjustPath( shapePath, width, height, size );
+
+            circlePath.setFillType( Path.FillType.EVEN_ODD );
+            circlePath.addPath( adjustedShape );
+            drawShadow( canvas, circlePath );
+            canvas.drawPath( circlePath, circlePaint );
+
+            if ( !isShapeTransparent() ) {
+                canvas.drawPath( adjustedShape, shapePaint );
+            }
+
+            return bitmap;
+        }
+
+        private int shadowSizeX() {
+            return (int) ( shadowRadius + Math.abs( shadowDx ) );
+        }
+
+        private int shadowSizeY() {
+            return (int) ( shadowRadius + Math.abs( shadowDy ) );
+        }
+
+        private boolean isShapeTransparent() {
+            return shapePaint.getAlpha() == 0;
+        }
+
+        private void drawShadow( Canvas canvas, Path shape ) {
+            if ( shadowRadius > 0 ) {
+                shadowPaint.setShadowLayer(
+                    shadowRadius,
+                    shadowDx,
+                    shadowDy,
+                    shadowColor );
+                canvas.drawPath( shape, shadowPaint );
+                circlePaint.setXfermode( new PorterDuffXfermode(
+                    PorterDuff.Mode.SRC_IN ) );
+            } else
+                circlePaint.setXfermode( null );
+        }
+
+        private void numberToPath( int stopNumber, Path path ) {
+            Paint textPaint = new Paint();
+            textPaint.setTypeface( Typeface.create(
+                Typeface.DEFAULT,
+                Typeface.BOLD ) );
+
+            String value = String.valueOf( stopNumber );
+            textPaint.setTextSize( 10 );
+            textPaint.getTextPath( value, 0, value.length(), 0, 0, path );
+        }
+
+        private void adjustPath(
+            Path shape,
+            float outerWidth,
+            float outerHeight,
+            float circleSize ) {
+            adjustedShape.reset();
+            adjustedShape.addPath( shape );
+
+            adjustedShape.computeBounds( bounds, true );
+            float currentSize = Math.max( bounds.width(), bounds.height() );
+            float scale = circleSize / currentSize * this.scale;
+            matrix.reset();
+            matrix.setScale( scale, scale );
+            adjustedShape.transform( matrix );
+
+            adjustedShape.computeBounds( bounds, true );
+            float centerX = outerWidth / 2;
+            float centerY = outerHeight / 2;
+            matrix.reset();
+            matrix.setTranslate(
+                centerX - ( bounds.right + bounds.left ) / 2,
+                centerY - ( bounds.bottom + bounds.top ) / 2 );
+            adjustedShape.transform( matrix );
+        }
+    }
+
+    @SuppressLint("NewApi")
+    public class BadgeCache extends LruCache<String, Bitmap> {
+        BadgeCache() {
+            super( 2 * 1024 * 1024 ); // 2MiB
+        }
+    }
+}

--- a/src/main/java/com/liefery/android/stop_badge/StopBadgeFactory.java
+++ b/src/main/java/com/liefery/android/stop_badge/StopBadgeFactory.java
@@ -2,7 +2,6 @@ package com.liefery.android.stop_badge;
 
 import android.annotation.SuppressLint;
 import android.graphics.*;
-import android.util.Log;
 import android.util.LruCache;
 
 @SuppressLint( "NewApi" )

--- a/src/main/java/com/liefery/android/stop_badge/StopBadgeView.java
+++ b/src/main/java/com/liefery/android/stop_badge/StopBadgeView.java
@@ -12,7 +12,7 @@ import android.util.AttributeSet;
 import android.widget.ImageView;
 
 public class StopBadgeView extends ImageView {
-    private StopBadgeFactory.StopBadgeCommonAttributesEditor stopBadgeBuilder;
+    private StopBadge stopBadge = new StopBadge();
 
     private Bitmap cache;
 
@@ -67,106 +67,104 @@ public class StopBadgeView extends ImageView {
     private void initialize( @NonNull TypedArray styles ) {
         setScaleType( ScaleType.CENTER );
 
-        stopBadgeBuilder = StopBadgeFactory.fromNothing();
-
         int shape = styles.getInt(
             R.styleable.StopBadgeView_stopBadge_shape,
             -1 );
         if ( shape == 0 )
-            stopBadgeBuilder = StopBadgeFactory.fromArrowUp();
+            setShapeArrowUp();
         else if ( shape == 1 )
-            stopBadgeBuilder = StopBadgeFactory.fromArrowDown();
+            setShapeArrowDown();
 
         int stopNumber = styles.getInt(
             R.styleable.StopBadgeView_stopBadge_stopNumber,
             -1 );
         if ( stopNumber != -1 )
-            stopBadgeBuilder = StopBadgeFactory.fromNumber( stopNumber );
+            setStopNumber( stopNumber );
 
         int circleColor = styles.getColor(
             R.styleable.StopBadgeView_stopBadge_circleColor,
             Integer.MIN_VALUE );
         if ( circleColor != Integer.MIN_VALUE )
-            stopBadgeBuilder.setCircleColor( circleColor );
+            stopBadge.setCircleColor( circleColor );
 
         int shapeColor = styles.getColor(
             R.styleable.StopBadgeView_stopBadge_shapeColor,
             Integer.MIN_VALUE );
         if ( shapeColor != Integer.MIN_VALUE )
-            stopBadgeBuilder.setShapeColor( shapeColor );
+            stopBadge.setShapeColor( shapeColor );
 
         int shadowColor = styles.getColor(
             R.styleable.StopBadgeView_stopBadge_shadowColor,
             Integer.MIN_VALUE );
         if ( shadowColor != Integer.MIN_VALUE )
-            stopBadgeBuilder.setShadowColor( shadowColor );
+            stopBadge.setShadowColor( shadowColor );
 
         float shadowDx = styles.getDimension(
             R.styleable.StopBadgeView_stopBadge_shadowDx,
             Integer.MIN_VALUE );
         if ( shadowDx != Integer.MIN_VALUE )
-            stopBadgeBuilder.setShadowDx( shadowDx );
+            stopBadge.setShadowDx( shadowDx );
 
         float shadowDy = styles.getDimension(
             R.styleable.StopBadgeView_stopBadge_shadowDy,
             Integer.MIN_VALUE );
         if ( shadowDy != Integer.MIN_VALUE )
-            stopBadgeBuilder.setShadowDy( shadowDy );
+            stopBadge.setShadowDy( shadowDy );
 
         float shadowRadius = styles.getDimension(
             R.styleable.StopBadgeView_stopBadge_shadowRadius,
             -1 );
         if ( shadowRadius != -1 )
-            stopBadgeBuilder.setShadowRadius( shadowRadius );
+            stopBadge.setShadowRadius( shadowRadius );
     }
 
     public void setCircleColor( @ColorInt int color ) {
-        stopBadgeBuilder.setCircleColor( color );
+        stopBadge.setCircleColor( color );
         invalidateAndReset();
     }
 
     public void setShapeColor( @ColorInt int color ) {
-        stopBadgeBuilder.setShapeColor( color );
+        stopBadge.setShapeColor( color );
         invalidateAndReset();
     }
 
     public void setShape( Path path ) {
-        stopBadgeBuilder = StopBadgeFactory.fromPath( path );
+        stopBadge.setShape( path );
         invalidateAndReset();
     }
 
     public void setShapeArrowUp() {
-        stopBadgeBuilder = StopBadgeFactory.fromArrowUp();
+        stopBadge.setShapeArrowUp();
         invalidateAndReset();
     }
 
     public void setShapeArrowDown() {
-        stopBadgeBuilder = StopBadgeFactory.fromArrowDown();
+        stopBadge.setShapeArrowDown();
         invalidateAndReset();
     }
 
     public void setStopNumber( int stopNumber ) {
-        stopBadgeBuilder = StopBadgeFactory.fromNumber( stopNumber );
+        stopBadge.setStopNumber( stopNumber );
         invalidateAndReset();
     }
 
     public void setShadowColor( @ColorInt int color ) {
-        stopBadgeBuilder.setShadowColor( color );
+        stopBadge.setShadowColor( color );
         invalidateAndReset();
     }
 
     public void setShadowDx( float dx ) {
-        stopBadgeBuilder.setShadowDx( dx );
+        stopBadge.setShadowDx( dx );
         invalidateAndReset();
     }
 
     public void setShadowDy( float dy ) {
-        stopBadgeBuilder.setShadowDy( dy );
+        stopBadge.setShadowDy( dy );
         invalidateAndReset();
     }
 
     public void setShadowRadius( float radius ) {
-        stopBadgeBuilder.setShadowRadius( radius );
+        stopBadge.setShadowRadius( radius );
         invalidateAndReset();
     }
 
@@ -183,7 +181,7 @@ public class StopBadgeView extends ImageView {
             int width = right - left;
             int height = bottom - top;
             int size = Math.min( width, height );
-            cache = stopBadgeBuilder.create( size );
+            cache = StopBadgeFactory.getBitmap( stopBadge, size );
             setImageBitmap( cache );
         }
     }

--- a/src/main/java/com/liefery/android/stop_badge/StopBadgeView.java
+++ b/src/main/java/com/liefery/android/stop_badge/StopBadgeView.java
@@ -12,7 +12,7 @@ import android.util.AttributeSet;
 import android.widget.ImageView;
 
 public class StopBadgeView extends ImageView {
-    private final StopBadge stopBadge = new StopBadge();
+    private StopBadgeFactory.StopBadgeCommonAttributesEditor stopBadgeBuilder;
 
     private Bitmap cache;
 
@@ -67,104 +67,106 @@ public class StopBadgeView extends ImageView {
     private void initialize( @NonNull TypedArray styles ) {
         setScaleType( ScaleType.CENTER );
 
-        int circleColor = styles.getColor(
-            R.styleable.StopBadgeView_stopBadge_circleColor,
-            Integer.MIN_VALUE );
-        if ( circleColor != Integer.MIN_VALUE )
-            setCircleColor( circleColor );
+        stopBadgeBuilder = StopBadgeFactory.fromNothing();
 
         int shape = styles.getInt(
             R.styleable.StopBadgeView_stopBadge_shape,
             -1 );
         if ( shape == 0 )
-            setShapeArrowUp();
+            stopBadgeBuilder = StopBadgeFactory.fromArrowUp();
         else if ( shape == 1 )
-            setShapeArrowDown();
-
-        int shapeColor = styles.getColor(
-            R.styleable.StopBadgeView_stopBadge_shapeColor,
-            Integer.MIN_VALUE );
-        if ( shapeColor != Integer.MIN_VALUE )
-            setShapeColor( shapeColor );
-
-        int shadowColor = styles.getColor(
-            R.styleable.StopBadgeView_stopBadge_shadowColor,
-            Integer.MIN_VALUE );
-        if ( shadowColor != Integer.MIN_VALUE )
-            setShadowColor( shadowColor );
-
-        float shadowDx = styles.getDimension(
-            R.styleable.StopBadgeView_stopBadge_shadowDx,
-            Integer.MIN_VALUE );
-        if ( shadowDx != Integer.MIN_VALUE )
-            setShadowDx( shadowDx );
-
-        float shadowDy = styles.getDimension(
-            R.styleable.StopBadgeView_stopBadge_shadowDy,
-            Integer.MIN_VALUE );
-        if ( shadowDy != Integer.MIN_VALUE )
-            setShadowDy( shadowDy );
-
-        float shadowRadius = styles.getDimension(
-            R.styleable.StopBadgeView_stopBadge_shadowRadius,
-            -1 );
-        if ( shadowRadius != -1 )
-            setShadowRadius( shadowRadius );
+            stopBadgeBuilder = StopBadgeFactory.fromArrowDown();
 
         int stopNumber = styles.getInt(
             R.styleable.StopBadgeView_stopBadge_stopNumber,
             -1 );
         if ( stopNumber != -1 )
-            setStopNumber( stopNumber );
+            stopBadgeBuilder = StopBadgeFactory.fromNumber( stopNumber );
+
+        int circleColor = styles.getColor(
+            R.styleable.StopBadgeView_stopBadge_circleColor,
+            Integer.MIN_VALUE );
+        if ( circleColor != Integer.MIN_VALUE )
+            stopBadgeBuilder.setCircleColor( circleColor );
+
+        int shapeColor = styles.getColor(
+            R.styleable.StopBadgeView_stopBadge_shapeColor,
+            Integer.MIN_VALUE );
+        if ( shapeColor != Integer.MIN_VALUE )
+            stopBadgeBuilder.setShapeColor( shapeColor );
+
+        int shadowColor = styles.getColor(
+            R.styleable.StopBadgeView_stopBadge_shadowColor,
+            Integer.MIN_VALUE );
+        if ( shadowColor != Integer.MIN_VALUE )
+            stopBadgeBuilder.setShadowColor( shadowColor );
+
+        float shadowDx = styles.getDimension(
+            R.styleable.StopBadgeView_stopBadge_shadowDx,
+            Integer.MIN_VALUE );
+        if ( shadowDx != Integer.MIN_VALUE )
+            stopBadgeBuilder.setShadowDx( shadowDx );
+
+        float shadowDy = styles.getDimension(
+            R.styleable.StopBadgeView_stopBadge_shadowDy,
+            Integer.MIN_VALUE );
+        if ( shadowDy != Integer.MIN_VALUE )
+            stopBadgeBuilder.setShadowDy( shadowDy );
+
+        float shadowRadius = styles.getDimension(
+            R.styleable.StopBadgeView_stopBadge_shadowRadius,
+            -1 );
+        if ( shadowRadius != -1 )
+            stopBadgeBuilder.setShadowRadius( shadowRadius );
     }
 
     public void setCircleColor( @ColorInt int color ) {
-        stopBadge.setCircleColor( color );
+        stopBadgeBuilder.setCircleColor( color );
         invalidateAndReset();
     }
 
     public void setShapeColor( @ColorInt int color ) {
-        stopBadge.setShapeColor( color );
+        stopBadgeBuilder.setShapeColor( color );
         invalidateAndReset();
     }
 
     public void setShape( Path path ) {
-        stopBadge.setShape( path );
+        stopBadgeBuilder = StopBadgeFactory.fromPath( path );
         invalidateAndReset();
     }
 
     public void setShapeArrowUp() {
-        stopBadge.setShapeArrowUp();
+        stopBadgeBuilder = StopBadgeFactory.fromArrowUp();
         invalidateAndReset();
     }
 
     public void setShapeArrowDown() {
-        stopBadge.setShapeArrowDown();
+        stopBadgeBuilder = StopBadgeFactory.fromArrowDown();
         invalidateAndReset();
     }
 
     public void setStopNumber( int stopNumber ) {
-        stopBadge.setStopNumber( stopNumber );
+        stopBadgeBuilder = StopBadgeFactory.fromNumber( stopNumber );
         invalidateAndReset();
     }
 
     public void setShadowColor( @ColorInt int color ) {
-        stopBadge.setShadowColor( color );
+        stopBadgeBuilder.setShadowColor( color );
         invalidateAndReset();
     }
 
     public void setShadowDx( float dx ) {
-        stopBadge.setShadowDx( dx );
+        stopBadgeBuilder.setShadowDx( dx );
         invalidateAndReset();
     }
 
     public void setShadowDy( float dy ) {
-        stopBadge.setShadowDy( dy );
+        stopBadgeBuilder.setShadowDy( dy );
         invalidateAndReset();
     }
 
     public void setShadowRadius( float radius ) {
-        stopBadge.setShadowRadius( radius );
+        stopBadgeBuilder.setShadowRadius( radius );
         invalidateAndReset();
     }
 
@@ -181,7 +183,7 @@ public class StopBadgeView extends ImageView {
             int width = right - left;
             int height = bottom - top;
             int size = Math.min( width, height );
-            cache = stopBadge.export( size );
+            cache = stopBadgeBuilder.create( size );
             setImageBitmap( cache );
         }
     }

--- a/src/main/java/com/liefery/android/stop_badge/StopBadgeView.java
+++ b/src/main/java/com/liefery/android/stop_badge/StopBadgeView.java
@@ -181,7 +181,7 @@ public class StopBadgeView extends ImageView {
             int width = right - left;
             int height = bottom - top;
             int size = Math.min( width, height );
-            cache = StopBadgeFactory.getBitmap( stopBadge, size );
+            cache = StopBadgeFactory.getBitmap( getContext(), stopBadge, size );
             setImageBitmap( cache );
         }
     }

--- a/src/main/java/com/liefery/android/stop_badge/StopBadgeView.java
+++ b/src/main/java/com/liefery/android/stop_badge/StopBadgeView.java
@@ -67,6 +67,12 @@ public class StopBadgeView extends ImageView {
     private void initialize( @NonNull TypedArray styles ) {
         setScaleType( ScaleType.CENTER );
 
+        int circleColor = styles.getColor(
+            R.styleable.StopBadgeView_stopBadge_circleColor,
+            Integer.MIN_VALUE );
+        if ( circleColor != Integer.MIN_VALUE )
+            setCircleColor( circleColor );
+
         int shape = styles.getInt(
             R.styleable.StopBadgeView_stopBadge_shape,
             -1 );
@@ -75,47 +81,41 @@ public class StopBadgeView extends ImageView {
         else if ( shape == 1 )
             setShapeArrowDown();
 
-        int stopNumber = styles.getInt(
-            R.styleable.StopBadgeView_stopBadge_stopNumber,
-            -1 );
-        if ( stopNumber != -1 )
-            setStopNumber( stopNumber );
-
-        int circleColor = styles.getColor(
-            R.styleable.StopBadgeView_stopBadge_circleColor,
-            Integer.MIN_VALUE );
-        if ( circleColor != Integer.MIN_VALUE )
-            stopBadge.setCircleColor( circleColor );
-
         int shapeColor = styles.getColor(
             R.styleable.StopBadgeView_stopBadge_shapeColor,
             Integer.MIN_VALUE );
         if ( shapeColor != Integer.MIN_VALUE )
-            stopBadge.setShapeColor( shapeColor );
+            setShapeColor( shapeColor );
 
         int shadowColor = styles.getColor(
             R.styleable.StopBadgeView_stopBadge_shadowColor,
             Integer.MIN_VALUE );
         if ( shadowColor != Integer.MIN_VALUE )
-            stopBadge.setShadowColor( shadowColor );
+            setShadowColor( shadowColor );
 
         float shadowDx = styles.getDimension(
             R.styleable.StopBadgeView_stopBadge_shadowDx,
             Integer.MIN_VALUE );
         if ( shadowDx != Integer.MIN_VALUE )
-            stopBadge.setShadowDx( shadowDx );
+            setShadowDx( shadowDx );
 
         float shadowDy = styles.getDimension(
             R.styleable.StopBadgeView_stopBadge_shadowDy,
             Integer.MIN_VALUE );
         if ( shadowDy != Integer.MIN_VALUE )
-            stopBadge.setShadowDy( shadowDy );
+            setShadowDy( shadowDy );
 
         float shadowRadius = styles.getDimension(
             R.styleable.StopBadgeView_stopBadge_shadowRadius,
             -1 );
         if ( shadowRadius != -1 )
-            stopBadge.setShadowRadius( shadowRadius );
+            setShadowRadius( shadowRadius );
+
+        int stopNumber = styles.getInt(
+            R.styleable.StopBadgeView_stopBadge_stopNumber,
+            -1 );
+        if ( stopNumber != -1 )
+            setStopNumber( stopNumber );
     }
 
     public void setCircleColor( @ColorInt int color ) {


### PR DESCRIPTION
Summary
-------
Cache caches `StopBadge`s. Cache can cache different sizes of the same `StopBadge`.

XML-defined `StopBadge`s and  Java defined `StopBadge`s will use the same cache. 

Different implementations of Java String's `.hashCode()` can be ignored since no Java Version interoperability is needed (Cache will always work with the Systems Java version, Cache does not persist Activity closure).

Sample Application log with added debug statements (not in this pull request):
--------
```
D  Creating image from Bitmap. Key: -417224202_131 //Java generated Bitmap
D  Creating image from Bitmap. Key: -435622200_131
D  Creating image from Bitmap. Key: -160205707_131
D  Creating image from Bitmap. Key: 1272704420_131
D  Creating image from Bitmap. Key: 1586678037_131
D  Creating image from Bitmap. Key: -28687095_131
D  Creating image from Bitmap. Key: 718919540_131
D  Getting from LruCache. Key: -417224202_131 //Being used by XML
D  Getting from LruCache. Key: -417224202_131
D  Creating image from Bitmap. Key: -1298919520_131
D  Creating image from Bitmap. Key: -208877566_131
D  Creating image from Bitmap. Key: -1235910623_131
```