### PR TITLE
[#LIEF-7783] IconBadge is missing offset when drawn to Bitmap

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,3 +1,3 @@
-addSbtPlugin( "com.lightbend.sbt" % "sbt-java-formatter" % "0.2.0" )
+//addSbtPlugin( "com.lightbend.sbt" % "sbt-java-formatter" % "0.2.0" )
 
 addSbtPlugin( "org.scala-android" % "sbt-android" % "1.7.10" )

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,3 +1,3 @@
-//addSbtPlugin( "com.lightbend.sbt" % "sbt-java-formatter" % "0.2.0" )
+addSbtPlugin( "com.lightbend.sbt" % "sbt-java-formatter" % "0.2.0" )
 
 addSbtPlugin( "org.scala-android" % "sbt-android" % "1.7.10" )

--- a/sample/src/main/java/com/liefery/android/icon_badge/sample/Activity.java
+++ b/sample/src/main/java/com/liefery/android/icon_badge/sample/Activity.java
@@ -21,7 +21,8 @@ public class Activity extends android.app.Activity {
         IconBadge badge = new IconBadge( this );
         badge.setBackgroundShapePin();
         badge.setBackgroundShapeColor( Color.RED );
-        badge.setForegroundShapeArrowUp();
+        badge.setNumber(1234);
+//        badge.setForegroundShapeArrowUp();
         badge.setForegroundShapeColor( Color.WHITE );
         badge.setElevation( dpToPx( 5 ) );
         image.setImageBitmap( badge.export( dpToPx( 50 ) ) );

--- a/sample/src/main/java/com/liefery/android/icon_badge/sample/Activity.java
+++ b/sample/src/main/java/com/liefery/android/icon_badge/sample/Activity.java
@@ -4,6 +4,7 @@ import android.content.res.Resources;
 import android.graphics.Color;
 import android.os.Bundle;
 import android.widget.ImageView;
+import android.support.v7.content.res.AppCompatResources;
 import com.liefery.android.icon_badge.IconBadge;
 
 public class Activity extends android.app.Activity {
@@ -25,5 +26,31 @@ public class Activity extends android.app.Activity {
         badge.setForegroundShapeColor( Color.WHITE );
         badge.setElevation( dpToPx( 5 ) );
         image.setImageBitmap( badge.export( dpToPx( 50 ) ) );
+    
+        ImageView image2 = findViewById( R.id.image2 );
+        IconBadge badge2 = new IconBadge( this );
+        badge2.setBackgroundShapeCircle();
+        badge2.setBackgroundShapeColor( Color.parseColor("#4CAF50") );
+        badge2.setForegroundDrawable(AppCompatResources.getDrawable( this, R.drawable.ic_checkmark_all ));
+        badge2.setForegroundShapeColor( Color.parseColor("#87000000") );
+        badge2.setElevation( dpToPx( 2 ) );
+        image2.setImageBitmap( badge2.export( dpToPx( 50 ) ) );
+    
+        ImageView image3 = findViewById( R.id.image3 );
+        IconBadge badge3 = new IconBadge( this );
+        badge3.setBackgroundShapePin();
+        badge3.setBackgroundShapeColor( Color.parseColor("#FFEB3B") );
+        badge3.setForegroundShapeArrowDown();
+        badge3.setForegroundShapeColor( Color.parseColor("#87000000") );
+        image3.setImageBitmap( badge3.export( dpToPx( 50 ) ) );
+    
+        ImageView image4 = findViewById( R.id.image4 );
+        IconBadge badge4 = new IconBadge( this );
+        badge4.setBackgroundShapeSquare();
+        badge4.setBackgroundShapeColor( Color.parseColor("#F44336") );
+        badge4.setNumber(69);
+        badge4.setForegroundShapeColor( Color.parseColor("#87ffffff") );
+        badge4.setElevation( dpToPx( 4 ) );
+        image4.setImageBitmap( badge4.export( dpToPx( 50 ) ) );
     }
 }

--- a/sample/src/main/java/com/liefery/android/icon_badge/sample/Activity.java
+++ b/sample/src/main/java/com/liefery/android/icon_badge/sample/Activity.java
@@ -21,8 +21,7 @@ public class Activity extends android.app.Activity {
         IconBadge badge = new IconBadge( this );
         badge.setBackgroundShapePin();
         badge.setBackgroundShapeColor( Color.RED );
-        badge.setNumber(1234);
-//        badge.setForegroundShapeArrowUp();
+        badge.setForegroundShapeArrowUp();
         badge.setForegroundShapeColor( Color.WHITE );
         badge.setElevation( dpToPx( 5 ) );
         image.setImageBitmap( badge.export( dpToPx( 50 ) ) );

--- a/sample/src/main/res/layout/main.xml
+++ b/sample/src/main/res/layout/main.xml
@@ -302,6 +302,107 @@
 
         </LinearLayout>
 
+        <TextView
+                android:layout_marginTop="32dp"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginBottom="16dp"
+                android:text="Android Views (Top) and exported Bitmaps (Bottom) are not distinguishable by eye."
+                android:textColor="#262626"
+                android:textSize="16sp"
+                android:textStyle="bold" />
+
+        <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:orientation="vertical"
+                android:clipChildren="false">
+
+            <LinearLayout
+                    android:layout_width="fill_parent"
+                    android:layout_height="wrap_content"
+                    android:orientation="horizontal"
+                    android:weightSum="3"
+                    android:clipChildren="false">
+
+                <LinearLayout
+                        android:layout_width="0dp"
+                        android:layout_height="wrap_content"
+                        android:layout_weight="1"
+                        android:orientation="vertical"
+                        android:clipChildren="false"
+                        android:gravity="center">
+
+                    <com.liefery.android.icon_badge.IconBadgeView
+                            android:layout_width="50dp"
+                            android:layout_height="50dp"
+                            android:layout_marginBottom="16dp"
+                            app:iconBadge_backgroundShapeColor="#4CAF50"
+                            app:iconBadge_foregroundShapeColor="#87000000"
+                            app:iconBadge_foregroundShapeDrawable="@drawable/ic_checkmark_all" />
+
+                    <ImageView
+                            android:id="@+id/image2"
+                            android:layout_width="50dp"
+                            android:layout_height="50dp"
+                            android:scaleType="center" />
+
+                </LinearLayout>
+
+                <LinearLayout
+                        android:layout_width="0dp"
+                        android:layout_height="wrap_content"
+                        android:layout_weight="1"
+                        android:orientation="vertical"
+                        android:clipChildren="false"
+                        android:gravity="center">
+
+                    <com.liefery.android.icon_badge.IconBadgeView
+                            android:layout_width="50dp"
+                            android:layout_height="50dp"
+                            android:layout_marginBottom="16dp"
+                            app:iconBadge_backgroundShapeColor="#FFEB3B"
+                            app:iconBadge_foregroundShapeColor="#87000000"
+                            app:iconBadge_foregroundShape="arrowDown"
+                            app:iconBadge_backgroundShape="pin"/>
+
+                    <ImageView
+                            android:id="@+id/image3"
+                            android:layout_width="50dp"
+                            android:layout_height="50dp"
+                            android:scaleType="center" />
+
+                </LinearLayout>
+
+                <LinearLayout
+                        android:layout_width="0dp"
+                        android:layout_height="wrap_content"
+                        android:layout_weight="1"
+                        android:orientation="vertical"
+                        android:clipChildren="false"
+                        android:gravity="center">
+
+                    <com.liefery.android.icon_badge.IconBadgeView
+                            android:layout_width="50dp"
+                            android:layout_height="50dp"
+                            android:layout_marginBottom="16dp"
+                            app:iconBadge_backgroundShapeColor="#F44336"
+                            app:iconBadge_foregroundShapeColor="#87ffffff"
+                            app:iconBadge_number="69"
+                            app:iconBadge_backgroundShape="square"/>
+
+                    <ImageView
+                            android:id="@+id/image4"
+                            android:layout_width="50dp"
+                            android:layout_height="50dp"
+                            android:scaleType="center" />
+
+                </LinearLayout>
+
+            </LinearLayout>
+
+        </LinearLayout>
+
     </LinearLayout>
 
 </ScrollView>

--- a/src/main/java/com/liefery/android/icon_badge/IconBadge.java
+++ b/src/main/java/com/liefery/android/icon_badge/IconBadge.java
@@ -42,7 +42,7 @@ public class IconBadge implements IconBadgeable {
     private int size = -1;
 
     private final Paint shadowPaint = new Paint( ANTI_ALIAS_FLAG );
-    
+
     private Matrix matrix = new Matrix();
 
     public IconBadge( Context context ) {
@@ -171,15 +171,20 @@ public class IconBadge implements IconBadgeable {
         }
 
         if ( foregroundShapeDrawer != null )
-            foregroundShapeDrawer.prepare( getForegroundShapeColor(), size, elevation );
+            foregroundShapeDrawer.prepare(
+                getForegroundShapeColor(),
+                size,
+                elevation );
     }
 
     public void draw( Canvas canvas ) {
         if ( backgroundProviderDrawingResult != null ) {
-            Path adjustedPath = adjustPathCenter(canvas.getWidth(), backgroundProviderDrawingResult);
-            canvas.drawPath(adjustedPath, backgroundShapePaint);
+            Path adjustedPath = adjustPathCenter(
+                canvas.getWidth(),
+                backgroundProviderDrawingResult );
+            canvas.drawPath( adjustedPath, backgroundShapePaint );
         }
-        
+
         if ( foregroundShapeDrawer != null )
             foregroundShapeDrawer.draw( canvas );
     }
@@ -225,14 +230,18 @@ public class IconBadge implements IconBadgeable {
         return bitmap;
     }
 
-    private void drawShadow( Canvas canvas, BackgroundProvider.Result backgroundResult ) {
+    private void drawShadow(
+        Canvas canvas,
+        BackgroundProvider.Result backgroundResult ) {
         shadowPaint.setShadowLayer(
             elevation * 1.5f,
             0f,
             elevation,
             Color.BLACK );
-        Path adjustedPath = adjustPathCenter(canvas.getWidth(), backgroundResult);
-        canvas.drawPath(adjustedPath, shadowPaint);
+        Path adjustedPath = adjustPathCenter(
+            canvas.getWidth(),
+            backgroundResult );
+        canvas.drawPath( adjustedPath, shadowPaint );
     }
 
     private Bitmap makeBitmapTransparent( Bitmap originalBitmap, float alpha ) {
@@ -249,12 +258,16 @@ public class IconBadge implements IconBadgeable {
 
         return bitmap;
     }
-    
-    private Path adjustPathCenter(int canvasWidth, BackgroundProvider.Result backgroundProviderDrawingResult) {
+
+    private Path adjustPathCenter(
+        int canvasWidth,
+        BackgroundProvider.Result backgroundProviderDrawingResult ) {
         matrix.reset();
-        matrix.setTranslate((canvasWidth - backgroundProviderDrawingResult.width) / 2, elevation);
-        Path adjustedPath = new Path(backgroundProviderDrawingResult.path);
-        adjustedPath.transform(matrix);
+        matrix.setTranslate(
+            ( canvasWidth - backgroundProviderDrawingResult.width ) / 2,
+            elevation );
+        Path adjustedPath = new Path( backgroundProviderDrawingResult.path );
+        adjustedPath.transform( matrix );
         return adjustedPath;
     }
 }

--- a/src/main/java/com/liefery/android/icon_badge/IconBadge.java
+++ b/src/main/java/com/liefery/android/icon_badge/IconBadge.java
@@ -42,6 +42,8 @@ public class IconBadge implements IconBadgeable {
     private int size = -1;
 
     private final Paint shadowPaint = new Paint( ANTI_ALIAS_FLAG );
+    
+    private Matrix matrix = new Matrix();
 
     public IconBadge( Context context ) {
         this.context = context;
@@ -173,14 +175,8 @@ public class IconBadge implements IconBadgeable {
     }
 
     public void draw( Canvas canvas ) {
-        // TODO shift path to be drawn in the center of the canvas
-        // when drawing a bitmap with shadow, it is currently aligned to the
-        // left of the canvas, but should horizontally centered
         if ( backgroundProviderDrawingResult != null ) {
-            Matrix matrix = new Matrix();
-            matrix.setTranslate((canvas.getWidth() - backgroundProviderDrawingResult.width) / 2, elevation);
-            Path adjustedPath = new Path(backgroundProviderDrawingResult.path);
-            adjustedPath.transform(matrix);
+            Path adjustedPath = adjustPathCenter(canvas.getWidth(), backgroundProviderDrawingResult);
             canvas.drawPath(adjustedPath, backgroundShapePaint);
         }
         
@@ -235,10 +231,7 @@ public class IconBadge implements IconBadgeable {
             0f,
             elevation,
             Color.BLACK );
-        Matrix matrix = new Matrix();
-        matrix.setTranslate((canvas.getWidth() - backgroundResult.width) / 2, elevation);
-        Path adjustedPath = new Path(backgroundResult.path);
-        adjustedPath.transform(matrix);
+        Path adjustedPath = adjustPathCenter(canvas.getWidth(), backgroundResult);
         canvas.drawPath(adjustedPath, shadowPaint);
     }
 
@@ -255,5 +248,13 @@ public class IconBadge implements IconBadgeable {
         canvas.drawBitmap( originalBitmap, 0, 0, alphaPaint );
 
         return bitmap;
+    }
+    
+    private Path adjustPathCenter(int canvasWidth, BackgroundProvider.Result backgroundProviderDrawingResult) {
+        matrix.reset();
+        matrix.setTranslate((canvasWidth - backgroundProviderDrawingResult.width) / 2, elevation);
+        Path adjustedPath = new Path(backgroundProviderDrawingResult.path);
+        adjustedPath.transform(matrix);
+        return adjustedPath;
     }
 }

--- a/src/main/java/com/liefery/android/icon_badge/foreground/DrawableForegroundDrawer.java
+++ b/src/main/java/com/liefery/android/icon_badge/foreground/DrawableForegroundDrawer.java
@@ -7,20 +7,27 @@ import android.support.v4.graphics.drawable.DrawableCompat;
 
 public class DrawableForegroundDrawer extends ForegroundShapeDrawer {
     private Drawable drawable;
+    private int size;
+    private int offset;
+    private int elevation;
 
     public DrawableForegroundDrawer( @NonNull Drawable drawable ) {
         this.drawable = DrawableCompat.wrap( drawable ).mutate();
     }
 
     @Override
-    public void prepare( int color, int size ) {
+    public void prepare( int color, int size, float elevation ) {
         DrawableCompat.setTint( drawable, color );
-        int offset = (int) Math.round( size * 0.2 );
-        drawable.setBounds( offset, offset, size - offset, size - offset );
+        this.offset = (int) Math.round( size * 0.2 );
+        this.size = size;
+        this.elevation = (int) elevation;
     }
 
     @Override
     public void draw( Canvas canvas ) {
+        int paddingWidth = (canvas.getWidth() - size) / 2;
+        
+        drawable.setBounds( offset + paddingWidth, offset + elevation, size - offset + paddingWidth, size - offset + elevation);
         drawable.draw( canvas );
     }
 }

--- a/src/main/java/com/liefery/android/icon_badge/foreground/DrawableForegroundDrawer.java
+++ b/src/main/java/com/liefery/android/icon_badge/foreground/DrawableForegroundDrawer.java
@@ -7,8 +7,11 @@ import android.support.v4.graphics.drawable.DrawableCompat;
 
 public class DrawableForegroundDrawer extends ForegroundShapeDrawer {
     private Drawable drawable;
+
     private int size;
+
     private int offset;
+
     private int elevation;
 
     public DrawableForegroundDrawer( @NonNull Drawable drawable ) {
@@ -25,9 +28,10 @@ public class DrawableForegroundDrawer extends ForegroundShapeDrawer {
 
     @Override
     public void draw( Canvas canvas ) {
-        int paddingWidth = (canvas.getWidth() - size) / 2;
-        
-        drawable.setBounds( offset + paddingWidth, offset + elevation, size - offset + paddingWidth, size - offset + elevation);
+        int paddingWidth = ( canvas.getWidth() - size ) / 2;
+
+        drawable.setBounds( offset + paddingWidth, offset + elevation, size
+            - offset + paddingWidth, size - offset + elevation );
         drawable.draw( canvas );
     }
 }

--- a/src/main/java/com/liefery/android/icon_badge/foreground/DrawableForegroundDrawer.java
+++ b/src/main/java/com/liefery/android/icon_badge/foreground/DrawableForegroundDrawer.java
@@ -10,9 +10,9 @@ public class DrawableForegroundDrawer extends ForegroundShapeDrawer {
 
     private int size;
 
-    private int offset;
+    private float offset;
 
-    private int elevation;
+    private float elevation;
 
     public DrawableForegroundDrawer( @NonNull Drawable drawable ) {
         this.drawable = DrawableCompat.wrap( drawable ).mutate();
@@ -21,17 +21,20 @@ public class DrawableForegroundDrawer extends ForegroundShapeDrawer {
     @Override
     public void prepare( int color, int size, float elevation ) {
         DrawableCompat.setTint( drawable, color );
-        this.offset = (int) Math.round( size * 0.2 );
+        this.offset = Math.round( size * 0.2 );
         this.size = size;
-        this.elevation = (int) elevation;
+        this.elevation = elevation;
     }
 
     @Override
     public void draw( Canvas canvas ) {
-        int paddingWidth = ( canvas.getWidth() - size ) / 2;
+        float paddingWidth = ( canvas.getWidth() - size ) / 2f;
 
-        drawable.setBounds( offset + paddingWidth, offset + elevation, size
-            - offset + paddingWidth, size - offset + elevation );
+        drawable.setBounds(
+            (int) ( offset + paddingWidth ),
+            (int) ( offset + elevation ),
+            (int) ( size - offset + paddingWidth ),
+            (int) ( size - offset + elevation ) );
         drawable.draw( canvas );
     }
 }

--- a/src/main/java/com/liefery/android/icon_badge/foreground/ForegroundShapeDrawer.java
+++ b/src/main/java/com/liefery/android/icon_badge/foreground/ForegroundShapeDrawer.java
@@ -5,7 +5,7 @@ import android.graphics.Paint;
 import android.support.annotation.ColorInt;
 
 public abstract class ForegroundShapeDrawer {
-    public abstract void prepare( @ColorInt int color, int size );
+    public abstract void prepare( @ColorInt int color, int size, float elevation );
 
     public abstract void draw( Canvas canvas );
 }

--- a/src/main/java/com/liefery/android/icon_badge/foreground/NumberShapeDrawer.java
+++ b/src/main/java/com/liefery/android/icon_badge/foreground/NumberShapeDrawer.java
@@ -9,10 +9,15 @@ import static android.graphics.Paint.ANTI_ALIAS_FLAG;
 
 public class NumberShapeDrawer extends ForegroundShapeDrawer {
     private final int number;
+
     private final String text;
+
     private final Paint paint = new Paint( ANTI_ALIAS_FLAG );
+
     private Rect rect = new Rect();
+
     private float y;
+
     private int size;
 
     public NumberShapeDrawer( int number ) {
@@ -29,7 +34,7 @@ public class NumberShapeDrawer extends ForegroundShapeDrawer {
 
         float scale = calculateScale( number );
         paint.setTextSize( size * 0.8f * scale );
-    
+
         this.size = size;
         this.y = calculateCenterVertical( size ) + elevation;
     }

--- a/src/main/java/com/liefery/android/icon_badge/foreground/NumberShapeDrawer.java
+++ b/src/main/java/com/liefery/android/icon_badge/foreground/NumberShapeDrawer.java
@@ -9,16 +9,11 @@ import static android.graphics.Paint.ANTI_ALIAS_FLAG;
 
 public class NumberShapeDrawer extends ForegroundShapeDrawer {
     private final int number;
-
     private final String text;
-
     private final Paint paint = new Paint( ANTI_ALIAS_FLAG );
-
     private Rect rect = new Rect();
-
-    private float x;
-
     private float y;
+    private int size;
 
     public NumberShapeDrawer( int number ) {
         this.number = number;
@@ -29,18 +24,19 @@ public class NumberShapeDrawer extends ForegroundShapeDrawer {
     }
 
     @Override
-    public void prepare( int color, int size ) {
+    public void prepare( int color, int size, float elevation ) {
         paint.setColor( color );
 
         float scale = calculateScale( number );
         paint.setTextSize( size * 0.8f * scale );
-
-        x = size / 2;
-        y = calculateCenterVertical( size );
+    
+        this.size = size;
+        this.y = calculateCenterVertical( size ) + elevation;
     }
 
     @Override
     public void draw( Canvas canvas ) {
+        int x = canvas.getWidth() / 2;
         canvas.drawText( text, x, y, paint );
     }
 

--- a/src/main/java/com/liefery/android/icon_badge/foreground/NumberShapeDrawer.java
+++ b/src/main/java/com/liefery/android/icon_badge/foreground/NumberShapeDrawer.java
@@ -18,8 +18,6 @@ public class NumberShapeDrawer extends ForegroundShapeDrawer {
 
     private float y;
 
-    private int size;
-
     public NumberShapeDrawer( int number ) {
         this.number = number;
         this.text = Integer.toString( number );
@@ -35,8 +33,7 @@ public class NumberShapeDrawer extends ForegroundShapeDrawer {
         float scale = calculateScale( number );
         paint.setTextSize( size * 0.8f * scale );
 
-        this.size = size;
-        this.y = calculateCenterVertical( size ) + elevation;
+        y = calculateCenterVertical( size ) + elevation;
     }
 
     @Override


### PR DESCRIPTION
Fixed shadow and badge drawing for exported images.

Closes #26 

![screenshot_20171115-171858](https://user-images.githubusercontent.com/6954968/32847158-7bffb4f2-ca29-11e7-95b5-2418d9d148c7.jpg)
